### PR TITLE
Update main.rs to have basic Print option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,23 @@ impl Todo {
         serde_json::to_writer_pretty(f, &self.map)?;
         Ok(())
     }
+
+    // Function to print the contents of db.json to the screen
+    // Currently stolen from Rust By Example
+    fn show(&mut self) {
+       if let Ok(lines) = Self::read_lines("./db.json") {
+           // Consumes the iterator returns option String
+           for line in lines.flatten() {
+               println!("{}", line);
+           }
+       } 
+    }
+
+    fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>> 
+    where P: AsRef<Path>, {
+        let file = File::open(filename)?;
+        Ok(io::BufReader::new(file).lines())
+    }
     
     fn complete(&mut self, key: &String) -> Option<()> {
         match self.map.get_mut(key) {


### PR DESCRIPTION
Added a very basic print function stolen from RustByExample. Call it with `cargo run show all`

TODO: Make second user input optional? Handle not having a second input more gracefully.